### PR TITLE
Add "stream-element" class for diaspora 0.6.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ Install Greasemonkey and [click here](https://github.com/Faldrian/diasporaAutoUp
 Changelog
 ---------
 
+28.09.2016
+**1.4.1**
+
+* Bugfix: Add `stream-element` class for diaspora\* 0.6.1.0.
+
 09.09.2016  
 **1.4.0**
 

--- a/src/Diaspora_AutoUpdater_(Wai-Modus).user.js
+++ b/src/Diaspora_AutoUpdater_(Wai-Modus).user.js
@@ -69,7 +69,7 @@
               $('#main_stream_refresh_button').remove();
               // The Button has to be inserted ON TOP of the entries, but BELOW the preview-area!
               var messageString = (newPostCount == 1) ? "new post" : "new posts";
-              window.d_autoupdater.latest_entry.before('<div id="main_stream_refresh_button" class="stream_element" style="border: 1px solid #3f8fba; background-color: #cae2ef; text-align:center;">' + newPostCount +' '+messageString+'</div>');
+              window.d_autoupdater.latest_entry.before('<div id="main_stream_refresh_button" class="stream-element stream_element" style="border: 1px solid #3f8fba; background-color: #cae2ef; text-align:center;">' + newPostCount +' '+messageString+'</div>');
 
               $('#main_stream_refresh_button').click(function() {
                 window.d_autoupdater.latest_entry.prevAll().css('display',''); // Show old entries

--- a/src/Diaspora_AutoUpdater_(Wai-Modus).user.js
+++ b/src/Diaspora_AutoUpdater_(Wai-Modus).user.js
@@ -6,7 +6,7 @@
 // @grant   none
 // @downloadURL https://github.com/Faldrian/diasporaAutoUpdate/raw/master/src/Diaspora_AutoUpdater_(Wai-Modus).user.js
 // @updateURL https://github.com/Faldrian/diasporaAutoUpdate/raw/master/src/Diaspora_AutoUpdater_(Wai-Modus).user.js
-// @version     1.4.0
+// @version     1.4.1
 // ==/UserScript==
 
 


### PR DESCRIPTION
Still let the deprecated `stream_element` class there for backward compatibility.