### PR TITLE
Use "background-color" from diaspora color-theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,12 @@ Install Greasemonkey and [click here](https://github.com/Faldrian/diasporaAutoUp
 Changelog
 ---------
 
-28.09.2016
+11.11.2016  
+**1.4.2**
+
+* Design: Use background-color from diaspora-theme.
+
+28.09.2016  
 **1.4.1**
 
 * Bugfix: Add `stream-element` class for diaspora\* 0.6.1.0.

--- a/src/Diaspora_AutoUpdater_(Wai-Modus).user.js
+++ b/src/Diaspora_AutoUpdater_(Wai-Modus).user.js
@@ -6,7 +6,7 @@
 // @grant   none
 // @downloadURL https://github.com/Faldrian/diasporaAutoUpdate/raw/master/src/Diaspora_AutoUpdater_(Wai-Modus).user.js
 // @updateURL https://github.com/Faldrian/diasporaAutoUpdate/raw/master/src/Diaspora_AutoUpdater_(Wai-Modus).user.js
-// @version     1.4.1
+// @version     1.4.2
 // ==/UserScript==
 
 

--- a/src/Diaspora_AutoUpdater_(Wai-Modus).user.js
+++ b/src/Diaspora_AutoUpdater_(Wai-Modus).user.js
@@ -19,6 +19,12 @@
     window.d_autoupdater.last_marked_entry = null;
     window.d_autoupdater.title = document.title;
 
+    let hiddenDiv = document.createElement("div");
+    hiddenDiv.style.display = "none";
+    hiddenDiv.className = "bg-info";
+    document.body.appendChild(hiddenDiv);
+    window.d_autoupdater.bg_color = getComputedStyle(hiddenDiv).getPropertyValue("background-color");
+
     window.d_autoupdater.setup = function() {
       // Model - Modifications: I have to override some functions to hack into backbone.js
       window.app.stream.autoreload_on = false;
@@ -69,7 +75,7 @@
               $('#main_stream_refresh_button').remove();
               // The Button has to be inserted ON TOP of the entries, but BELOW the preview-area!
               var messageString = (newPostCount == 1) ? "new post" : "new posts";
-              window.d_autoupdater.latest_entry.before('<div id="main_stream_refresh_button" class="stream-element stream_element" style="border: 1px solid #3f8fba; background-color: #cae2ef; text-align:center;">' + newPostCount +' '+messageString+'</div>');
+              window.d_autoupdater.latest_entry.before('<div id="main_stream_refresh_button" class="stream-element stream_element" style="border: 1px solid #3f8fba; background-color: ' + window.d_autoupdater.bg_color + '; text-align:center;">' + newPostCount +' '+messageString+'</div>');
 
               $('#main_stream_refresh_button').click(function() {
                 window.d_autoupdater.latest_entry.prevAll().css('display',''); // Show old entries


### PR DESCRIPTION
The hardcoded `background-color` doesn't work well with the new diaspora dark-theme.

Default theme:
![default-theme](https://cloud.githubusercontent.com/assets/458548/20201927/e8de6762-a7bb-11e6-9f67-c367e0d733fb.png)

Dark theme:
![dark-theme](https://cloud.githubusercontent.com/assets/458548/20201929/efdd2198-a7bb-11e6-956a-96f67dad51f9.png)